### PR TITLE
Sanitize trackingIdString in SQL statement

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -247,9 +247,9 @@ export function handler<E>(input: HandlerInput<E>, opts?: HandlerOptions) {
                         const trackingStub = trackingNamespace.get(trackingId) as unknown as Actor<E>;
                         trackingStub.setIdentifier(trackingIdString);
                         
-                        trackingStub.sql`CREATE TABLE IF NOT EXISTS actors (identifier TEXT PRIMARY KEY, last_accessed TEXT)`;
+                        await trackingStub.__studio({ type: 'query', statement: 'CREATE TABLE IF NOT EXISTS actors (identifier TEXT PRIMARY KEY, last_accessed TEXT)' });
                         const currentDateTime = new Date().toISOString();
-                        trackingStub.sql`INSERT INTO actors (identifier, last_accessed) VALUES ('${trackingIdString}', '${currentDateTime}') ON CONFLICT(identifier) DO UPDATE SET last_accessed = '${currentDateTime}'`;
+                        await trackingStub.__studio({ type: 'query', statement: `INSERT INTO actors (identifier, last_accessed) VALUES (?, ?) ON CONFLICT(identifier) DO UPDATE SET last_accessed = ?`, params: [trackingIdString, currentDateTime, currentDateTime] });
                     }
 
                     return stub.fetch(request);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -247,9 +247,9 @@ export function handler<E>(input: HandlerInput<E>, opts?: HandlerOptions) {
                         const trackingStub = trackingNamespace.get(trackingId) as unknown as Actor<E>;
                         trackingStub.setIdentifier(trackingIdString);
                         
-                        await trackingStub.__studio({ type: 'query', statement: 'CREATE TABLE IF NOT EXISTS actors (identifier TEXT PRIMARY KEY, last_accessed TEXT)' });
+                        trackingStub.sql`CREATE TABLE IF NOT EXISTS actors (identifier TEXT PRIMARY KEY, last_accessed TEXT)`;
                         const currentDateTime = new Date().toISOString();
-                        await trackingStub.__studio({ type: 'query', statement: `INSERT INTO actors (identifier, last_accessed) VALUES ('${trackingIdString}', '${currentDateTime}') ON CONFLICT(identifier) DO UPDATE SET last_accessed = '${currentDateTime}'` });
+                        trackingStub.sql`INSERT INTO actors (identifier, last_accessed) VALUES ('${trackingIdString}', '${currentDateTime}') ON CONFLICT(identifier) DO UPDATE SET last_accessed = '${currentDateTime}'`;
                     }
 
                     return stub.fetch(request);

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -19,11 +19,13 @@ interface SqlStorage {
 interface StudioQueryRequest {
 	type: 'query';
 	statement: string;
+    params?: any[]
 }
 
 interface StudioTransactionRequest {
 	type: 'transaction';
 	statements: string[];
+    params?: any[]
 }
 
 type StudioRequest = StudioQueryRequest | StudioTransactionRequest;
@@ -185,12 +187,12 @@ export class Storage {
         const storage = this.raw as DurableObjectStorage;
 
         if (cmd.type === 'query') {
-            return this.query(cmd.statement);
+            return this.query(cmd.statement, cmd.params);
         } else if (cmd.type === 'transaction') {
             return storage.transaction(async () => {
                 const results = [];
                 for (const statement of cmd.statements) {
-                    results.push(await this.query(statement, undefined, true));
+                    results.push(await this.query(statement, cmd.params, true));
                 }
 
                 return results;


### PR DESCRIPTION
Previously the `trackingIdString` was part of the query string without being bound to the query as a param or sanitized.

Resolves #15 