### PR TITLE
getActor to always return a stub or throw exception

### DIFF
--- a/examples/playground/src/index.ts
+++ b/examples/playground/src/index.ts
@@ -52,7 +52,7 @@ export class MyWorker extends Worker<Env> {
 export class MyRPCWorker extends Worker<Env> {
     async fetch(request: Request): Promise<Response> {
         const actor = MyStorageActor.get('default');
-        const result = await actor?.add(2, 3);
+        const result = await actor.add(2, 3);
         return new Response(`Answer = ${result}`);
     }
 }
@@ -69,7 +69,7 @@ export class MyInstancesNamesWorker extends Worker<Env> {
         // instance names are stored in another instance with a default name of
         // `_cf_actors`.
         const trackerActor = MyStorageActor.get('_cf_actors');
-        const query = await trackerActor!.sql`SELECT * FROM actors;`
+        const query = await trackerActor.sql`SELECT * FROM actors;`
         return new Response(JSON.stringify(query), { headers: { 'Content-Type': 'application/json' } })
     }
 }
@@ -83,7 +83,7 @@ export class MyDeleteInstanceWorker extends Worker<Env> {
     async fetch(request: Request): Promise<Response> {
         // Deleting a specific instance inside our tracking instance
         const actor = MyStorageActor.get('foobar');
-        await actor?.destroy({ trackingInstance: '_cf_actors' });
+        await actor.destroy({ trackingInstance: '_cf_actors' });
         return new Response('Actor deleted');
     }
 }
@@ -96,7 +96,7 @@ export class MyDeleteInstanceWorker extends Worker<Env> {
 export class MyRPCActor extends Actor<Env> {
     async fetch(request: Request): Promise<Response> {
         const actor = MyStorageActor.get('default');
-        const result = await actor?.add(3, 4);
+        const result = await actor.add(3, 4);
         return new Response(`Answer = ${result}`);
     }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,8 +59,9 @@ export abstract class Actor<E> extends DurableObject<E> {
      * @param id - The ID of the actor to get
      * @returns The actor instance
      */
-    static get<T extends Actor<any>>(this: new (state: ActorState, env: any) => T, id: string): DurableObjectStub<T> | undefined {
-        return getActor(this, id);
+    static get<T extends Actor<any>>(this: new (state: ActorState, env: any) => T, id: string): DurableObjectStub<T> {
+        const stub = getActor(this, id);
+        return stub;
     }
 
     /**
@@ -283,7 +284,7 @@ export function handler<E>(input: HandlerInput<E>, opts?: HandlerOptions) {
 export function getActor<T extends Actor<any>>(
     ActorClass: new (state: ActorState, env: any) => T,
     id: string
-): DurableObjectStub<T> | undefined {
+): DurableObjectStub<T> {
     const className = ActorClass.name;
     const envObj = env as unknown as Record<string, DurableObjectNamespace>;
     
@@ -292,7 +293,9 @@ export function getActor<T extends Actor<any>>(
         return key === className || binding?.class_name === className;
     });
 
-    if (!bindingName) return undefined;
+    if (!bindingName) {
+        throw new Error(`No Durable Object binding found for actor class ${className}. Check update your wrangler.jsonc to match the binding "name" and "class_name" to be the same as the class name.`);
+    }
 
     const namespace = envObj[bindingName];
     const stubId = namespace.idFromName(id);


### PR DESCRIPTION
Similar to how `DurableObjectNamespace.get` always returns a stub, our `getActor` or `.get(...)` should also always return a stub, rather than `undefined` as an option. This allows an exception to be thrown to the user when the class name is not defined correctly, and also prevents the need for optional values to be qualified before usage (e.g. no longer need `actor?.sum(1, 2)` and can safely do `actor.sum(1, 2)`).

Resolves #21 