### PR TITLE
Use getActor when a stub reference is needed

### DIFF
--- a/examples/playground/src/index.ts
+++ b/examples/playground/src/index.ts
@@ -98,7 +98,7 @@ export class MyRPCActor extends Actor<Env> {
         super(ctx, env);
     
         this.ctx.blockConcurrencyWhile(async () => {
-            console.log('Constructor Identifier: ', this.identifier)
+            console.log('ID: ', this.identifier)
         });
     }
 
@@ -115,11 +115,6 @@ export class MyRPCActor extends Actor<Env> {
 // Example Actor with storage package interactions
 // -----------------------------------------------
 export class MyStorageActor extends Actor<Env> {
-    // Defined a custom name within the Actor to reference the Actor instance
-    static nameFromRequest(request: Request) {
-        return "foobar"
-    }
-
     constructor(ctx?: ActorState, env?: Env) {
         super(ctx, env);
 

--- a/examples/playground/src/index.ts
+++ b/examples/playground/src/index.ts
@@ -29,9 +29,9 @@ import { Alarms } from "../../../packages/alarms/src";
 // -----------------------------------------------------
 // Example response without explicitly defining a Worker
 // -----------------------------------------------------
-export default handler((request: Request) => {
-    return new Response('Hello, World!')
-});
+// export default handler((request: Request) => {
+//     return new Response('Hello, World!')
+// });
 
 
 // -------------------------------------------------
@@ -73,7 +73,7 @@ export class MyInstancesNamesWorker extends Worker<Env> {
         return new Response(JSON.stringify(query), { headers: { 'Content-Type': 'application/json' } })
     }
 }
-// export default handler(MyInstancesNamesWorker);
+export default handler(MyInstancesNamesWorker);
 
 
 // ---------------------------------------------------

--- a/examples/playground/src/index.ts
+++ b/examples/playground/src/index.ts
@@ -29,9 +29,9 @@ import { Alarms } from "../../../packages/alarms/src";
 // -----------------------------------------------------
 // Example response without explicitly defining a Worker
 // -----------------------------------------------------
-// export default handler((request: Request) => {
-//     return new Response('Hello, World!')
-// });
+export default handler((request: Request) => {
+    return new Response('Hello, World!')
+});
 
 
 // -------------------------------------------------
@@ -73,7 +73,7 @@ export class MyInstancesNamesWorker extends Worker<Env> {
         return new Response(JSON.stringify(query), { headers: { 'Content-Type': 'application/json' } })
     }
 }
-export default handler(MyInstancesNamesWorker);
+// export default handler(MyInstancesNamesWorker);
 
 
 // ---------------------------------------------------
@@ -94,6 +94,14 @@ export class MyDeleteInstanceWorker extends Worker<Env> {
 // Example Actor with RPC calling into another Actor
 // -------------------------------------------------
 export class MyRPCActor extends Actor<Env> {
+    constructor(ctx: DurableObjectState, env: Env) {
+        super(ctx, env);
+    
+        this.ctx.blockConcurrencyWhile(async () => {
+            console.log('Constructor Identifier: ', this.identifier)
+        });
+    }
+
     async fetch(request: Request): Promise<Response> {
         const actor = MyStorageActor.get('default');
         const result = await actor.add(3, 4);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -233,9 +233,8 @@ export function handler<E>(input: HandlerInput<E>, opts?: HandlerOptions) {
                         }
 
                         const trackingStub = getActor(ObjectClass as ActorConstructor<Actor<E>>, trackingName) as unknown as Actor<E>;
-                        
-                        await trackingStub.__studio({ type: 'query', statement: 'CREATE TABLE IF NOT EXISTS actors (identifier TEXT PRIMARY KEY, last_accessed TEXT)' });
                         const currentDateTime = new Date().toISOString();
+                        await trackingStub.__studio({ type: 'query', statement: 'CREATE TABLE IF NOT EXISTS actors (identifier TEXT PRIMARY KEY, last_accessed TEXT)' });
                         await trackingStub.__studio({ type: 'query', statement: `INSERT INTO actors (identifier, last_accessed) VALUES (?, ?) ON CONFLICT(identifier) DO UPDATE SET last_accessed = ?`, params: [idString, currentDateTime, currentDateTime] });
                     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,12 @@ export abstract class Actor<E> extends DurableObject<E> {
      */
     static get<T extends Actor<any>>(this: new (state: ActorState, env: any) => T, id: string): DurableObjectStub<T> {
         const stub = getActor(this, id);
+
+        // This may seem repetitive from when we do this in `getActor` prior to returning the stub
+        // but this allows classes to do `this.ctx.blockConcurrencyWhile` and log out the identifier
+        // there. Without doing this again, that seems to fail for one reason or another.
+        stub.setIdentifier(id);
+
         return stub;
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -236,7 +236,7 @@ export function handler<E>(input: HandlerInput<E>, opts?: HandlerOptions) {
                         
                         await trackingStub.__studio({ type: 'query', statement: 'CREATE TABLE IF NOT EXISTS actors (identifier TEXT PRIMARY KEY, last_accessed TEXT)' });
                         const currentDateTime = new Date().toISOString();
-                        await trackingStub.__studio({ type: 'query', statement: `INSERT INTO actors (identifier, last_accessed) VALUES (?, ?) ON CONFLICT(identifier) DO UPDATE SET last_accessed = ?`, params: [trackingName, currentDateTime, currentDateTime] });
+                        await trackingStub.__studio({ type: 'query', statement: `INSERT INTO actors (identifier, last_accessed) VALUES (?, ?) ON CONFLICT(identifier) DO UPDATE SET last_accessed = ?`, params: [idString, currentDateTime, currentDateTime] });
                     }
 
                     return stub.fetch(request);
@@ -282,6 +282,6 @@ export function getActor<T extends Actor<any>>(
     const namespace = envObj[bindingName];
     const stubId = namespace.idFromName(id);
     const stub = namespace.get(stubId) as DurableObjectStub<T>;
-    stub.setIdentifier(id); // <- This does not work as expected
+    stub.setIdentifier(id);
     return stub;
 }


### PR DESCRIPTION
Currently there are two places that are constructing their own stub logic repetitively where we already have our `getActor` function that can do this for us. This PR condenses all places to use the same function for shared logic handling.

Resolves #18 