### PR TITLE
Include forceEviction option in destroy

### DIFF
--- a/examples/playground/src/index.ts
+++ b/examples/playground/src/index.ts
@@ -79,21 +79,21 @@ export class MyInstancesNamesWorker extends Entrypoint<Env> {
 // ---------------------------------------------------
 // Example Worker deleting single instance of an Actor
 // ---------------------------------------------------
-// export class MyDeleteInstanceWorker extends Entrypoint<Env> {
-//     async fetch(request: Request): Promise<Response> {
-//         // Deleting a specific instance inside our tracking instance
-//         const actor = MyStorageActor.get('foobar');
+export class MyDeleteInstanceWorker extends Entrypoint<Env> {
+    async fetch(request: Request): Promise<Response> {
+        // Deleting a specific instance inside our tracking instance
+        const actor = MyStorageActor.get('foobar');
         
-//         // Wrap in a try/catch because the `forceEviction` flag of an Actor instance
-//         // will throw an exception which is propogated back through the RPC mechanism
-//         // of our worker.
-//         try {
-//             await actor.destroy({ trackingInstance: '_cf_actors', forceEviction: true });
-//         } catch (e) { }
+        // Wrap in a try/catch because the `forceEviction` flag of an Actor instance
+        // will throw an exception which is propogated back through the RPC mechanism
+        // of our worker.
+        try {
+            await actor.destroy({ forceEviction: true });
+        } catch (e) { }
 
-//         return new Response('Actor deleted');
-//     }
-// }
+        return new Response('Actor deleted');
+    }
+}
 // export default handler(MyDeleteInstanceWorker);
 
 


### PR DESCRIPTION
Instead of always running the `this.ctx.abort("destroyed");` code when calling `Actor.destroy()` we are wrapping it in an option named `forceEviction` that is false by default.

When you do decide to opt in to the `forceEviction` we would recommend wrapping this logic in a try/catch block. The reason behind this is because when we do an RPC call into a Durable Object instance, this particular code execution to `abort` will throw an exception which in turn returns that response to the caller (in the below example would be the `MyDeleteInstanceEntrypoint`). Without it wrapped in a try/catch the implementing class will also throw that exception and your code execution will end.

```typescript
export class MyDeleteInstanceEntrypoint extends Entrypoint<Env> {
    async fetch(request: Request): Promise<Response> {
        // Deleting a specific instance inside our tracking instance
        const actor = MyStorageActor.get('foobar');
        
        // Wrap in a try/catch because the `forceEviction` flag of an Actor instance
        // will throw an exception which is propogated back through the RPC mechanism
        // of our worker.
        try {
            await actor.destroy({ forceEviction: true });
        } catch (e) { }

        return new Response('Actor deleted');
    }
}
export default handler(MyDeleteInstanceWorker);
```

Resolves #28 