### PR TITLE
Support location hint for Actors

### DIFF
--- a/examples/playground/src/index.ts
+++ b/examples/playground/src/index.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers"
-import { Actor, handler, Entrypoint, ActorState } from '../../../packages/core/src'
+import { Actor, handler, Entrypoint, ActorState, ActorConfiguration } from '../../../packages/core/src'
 import { Storage } from '../../../packages/storage/src'
 import { Alarms } from "../../../packages/alarms/src";
 
@@ -115,6 +115,14 @@ export class MyRPCActor extends Actor<Env> {
 // Example Actor with storage package interactions
 // -----------------------------------------------
 export class MyStorageActor extends Actor<Env> {
+    static nameFromRequest(request: Request) {
+        return "foobar"
+    }
+
+    static configuration(request: Request): ActorConfiguration {
+        return { locationHint: "apac" };
+    }
+
     constructor(ctx?: ActorState, env?: Env) {
         super(ctx, env);
 

--- a/examples/playground/src/index.ts
+++ b/examples/playground/src/index.ts
@@ -111,16 +111,31 @@ export class MyRPCActor extends Actor<Env> {
 // export default handler(MyRPCActor);
 
 
+// ------------------------------------------
+// Example Actor with location hints enabled
+// ------------------------------------------
+export class MyLocationHintActor extends Actor<Env> {
+    static configuration(request: Request): ActorConfiguration {
+        return { locationHint: "apac" };
+    }
+
+    async fetch(request: Request): Promise<Response> {
+        // Make a request to get the current colo information
+        const response = await fetch("https://cloudflare.com/cdn-cgi/trace");
+        const colos = await response.text();
+
+        return new Response(colos);
+    }
+}
+// export default handler(MyLocationHintActor);
+
+
 // -----------------------------------------------
 // Example Actor with storage package interactions
 // -----------------------------------------------
 export class MyStorageActor extends Actor<Env> {
     static nameFromRequest(request: Request) {
         return "foobar"
-    }
-
-    static configuration(request: Request): ActorConfiguration {
-        return { locationHint: "apac" };
     }
 
     constructor(ctx?: ActorState, env?: Env) {

--- a/examples/playground/wrangler.jsonc
+++ b/examples/playground/wrangler.jsonc
@@ -10,7 +10,8 @@
 				"MyRPCActor",
 				"MyStorageActor",
                 "MyAlarmActor",
-				"MyDurableObject"
+				"MyDurableObject",
+				"MyLocationHintActor"
 			],
 			"tag": "v1"
 		}
@@ -32,6 +33,10 @@
 			{
 				"class_name": "MyDurableObject",
 				"name": "MyDurableObject"
+			},
+			{
+				"class_name": "MyLocationHintActor",
+				"name": "MyLocationHintActor"
 			}
 		]
 	},

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -303,7 +303,7 @@ export function getActor<T extends Actor<any>>(
 
     const namespace = envObj[bindingName];
     const stubId = namespace.idFromName(id);
-    const stub = locationHint ? namespace.get(stubId, { locationHint }) as DurableObjectStub<T> : namespace.get(stubId) as DurableObjectStub<T>;
+    const stub = namespace.get(stubId, { locationHint }) as DurableObjectStub<T>;
     
     stub.setIdentifier(id);
     return stub;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,7 @@ export type ActorConstructor<T extends Actor<any> = Actor<any>> = new (state: Ac
  * Configuration options for an actor.
  */
 export type ActorConfiguration = {
-    locationHint?: 'wnam' | 'enam' | 'sam' | 'weur' | 'eeur' | 'apac' | 'oc' | 'afr' | 'me';
+    locationHint?: DurableObjectLocationHint;
 }
 
 /**


### PR DESCRIPTION
When an Actor is self-contained without a user defined Worker to call into it, the Actor should be able to dictate which region it should be deployed to on its first call. This PR introduces a `configuration` static function that only supports `locationHint` today but can be used for more configurable options (e.g. websocket hibernation) in the future without the need to introduce a new static method for every configurable piece later.

Supports the following regions:
```typescript
locationHint?: 'wnam' | 'enam' | 'sam' | 'weur' | 'eeur' | 'apac' | 'oc' | 'afr' | 'me';
```

Example:
```typescript
static configuration(request: Request): ActorConfiguration {
    return { locationHint: "apac" };
}
```

See documentation for Durable Object location hints: https://developers.cloudflare.com/durable-objects/reference/data-location/#provide-a-location-hint