### PR TITLE
fix: exclude list & add WebSocket support to recipients

### DIFF
--- a/packages/sockets/src/index.ts
+++ b/packages/sockets/src/index.ts
@@ -42,24 +42,14 @@ export class Sockets<P extends DurableObject<any>> {
 
     message(message: string, to?: RecipientType[] | '*', exclude?: RecipientType[]) {
         for (const [id, socket] of this.connections.entries()) {
-            // If no `to` recipient is defined, default send message to everyone
-            if (to === '*' || !to || to?.length === 0) {
-                // If the `id` is in the exclude list then skip this iteration
-                if (exclude?.includes(id)) {
-                    continue;
-                }
+            // Skip if the `id` or `socket` is in the `exclude` list
+            if (exclude?.includes(id) || exclude?.includes(socket)) {
+              continue;
+            }
 
-                // If the `socket` is in the exclude list then skip this iteration
-                if (exclude?.includes(socket)) {
-                    continue;
-                }
-
-                // Send message if the `to` is not excluded
-                socket.send(message);
-            } else if (to?.includes(id)) {
-                // When `to` is defined we only send the message to the
-                // specified recipients.
-                socket.send(message);
+            // Send to all if 'to' is '*' or empty, otherwise only to specified recipients
+            if (to === "*" || !to?.length || to.includes(id) || to.includes(socket)) {
+              socket.send(message);
             }
         }
     }


### PR DESCRIPTION
**Describe the bug**
1. When a recipient is included in both the `to` and `exclude` lists, they still receive the message.
2. When we add a `WebSocket` object to the `to` or `exclude` list instead of a `connectionId`, messages are not sent to or excluded from that client.

**Expected behavior**
1. The `exclude` list takes priority, ensuring the message is never sent to those.
2. Support both the `connectionId` and the `WebSocket` object.

**Fix**
- Recipients are now correctly excluded even if they are in both the `to` and `exclude` lists.
- Added `WebSocket` support for `to` and `exlude` lists.