### PR TITLE
Run migrations only on explicit call

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -151,9 +151,6 @@ export class Storage {
      * @returns Promise resolving to either raw query results or formatted array
      */
     private async query(sql: string, params?: unknown[], isRaw?: boolean) {
-        // Attempt to run migrations if they have not been ran already
-        this.runMigrations();
-
         // Now proceed with executing the query
         const cursor = await this.executeRawQuery({ sql, params })
         if (!cursor) return []


### PR DESCRIPTION
Currently when a user has migrations set and they attempt to `runMigrations` in the `onInit` hook, the migrations never take place. That's because in the Storage class we are trying to `runMigrations()` when a query is ran automatically on behalf of the user, which happens prematurely and sets a flag to not run migrations again.

This fix removes the attempt to automatically `runMigrations` and let the user explicitly tell the system when to run them.

Fixes #74 