### PR TITLE
Socket rename, async, and attachment tweaks

### DIFF
--- a/examples/sockets/src/index.ts
+++ b/examples/sockets/src/index.ts
@@ -18,7 +18,7 @@ export class MySocketsActor extends Actor<Env> {
         return Promise.resolve(Response.json({ message: 'Hello, World!' }));
     }
 
-    protected shouldUpgradeSocket(request: Request): boolean {
+    protected async shouldUpgradeWebSocket(request: Request): Promise<boolean> {
         return true;
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,7 +243,7 @@ export abstract class Actor<E> extends DurableObject<E> {
         const url = new URL(request.url);
         const upgradePath = config?.sockets?.upgradePath ?? "/ws";
         if (url.pathname === upgradePath || url.pathname.startsWith(`${upgradePath}/`)) {
-            const shouldUpgrade = this.shouldUpgradeWebSocket(request);
+            const shouldUpgrade = await this.shouldUpgradeWebSocket(request);
             
             // Only continue to upgrade path if shouldUpgrade returns true
             if (shouldUpgrade) {
@@ -303,7 +303,7 @@ export abstract class Actor<E> extends DurableObject<E> {
         return Promise.resolve(new Response("Not Found", { status: 404 }));
     }
 
-    protected shouldUpgradeWebSocket(request: Request): boolean {
+    protected async shouldUpgradeWebSocket(request: Request): Promise<boolean> {
         // By default we do not want to assume every application needs to use sockets
         // and we do not want to upgrade every request to a socket.
         return false;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,7 +243,7 @@ export abstract class Actor<E> extends DurableObject<E> {
         const url = new URL(request.url);
         const upgradePath = config?.sockets?.upgradePath ?? "/ws";
         if (url.pathname === upgradePath || url.pathname.startsWith(`${upgradePath}/`)) {
-            const shouldUpgrade = this.shouldUpgradeSocket(request);
+            const shouldUpgrade = this.shouldUpgradeWebSocket(request);
             
             // Only continue to upgrade path if shouldUpgrade returns true
             if (shouldUpgrade) {
@@ -303,7 +303,7 @@ export abstract class Actor<E> extends DurableObject<E> {
         return Promise.resolve(new Response("Not Found", { status: 404 }));
     }
 
-    protected shouldUpgradeSocket(request: Request): boolean {
+    protected shouldUpgradeWebSocket(request: Request): boolean {
         // By default we do not want to assume every application needs to use sockets
         // and we do not want to upgrade every request to a socket.
         return false;

--- a/packages/sockets/src/index.ts
+++ b/packages/sockets/src/index.ts
@@ -95,9 +95,6 @@ export class Sockets<P extends DurableObject<any>> {
         
         // If no ID was provided, generate one
         const connectionId = queryParams.id || crypto.randomUUID();
-        if (!queryParams.id) {
-            queryParams.id = connectionId;
-        }
         
         // Store all query parameters in the WebSocket's attachment to persist across hibernation
         if (server.serializeAttachment) {


### PR DESCRIPTION
I've made a few changes based on recommendations in issue #76.

- Rename shouldUpgradeSocket -> shouldUpgradeWebSocket
- Allow shouldUpgradeWebSocket to be async/await-able
- Remove queryParams.id if the ID was never passed in as a query param (instead reference connectionId)

Fixes #76 