### PR TITLE
Export SQL Migration type

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,6 +1,8 @@
 import type { DurableObjectStorage } from "@cloudflare/workers-types";
 import { SQLSchemaMigration, SQLSchemaMigrations } from "./sql-schema-migrations";
 
+export type { SQLSchemaMigration };
+
 /**
  * Represents a single SQL query request with optional parameters.
  */


### PR DESCRIPTION
Instead of always defining the array in the constructor this would allow you to easily declare it outside of your class, which is currently a bit awkward.

Before:
```ts
  constructor(ctx: DurableObjectState, env: Env) {
    super(ctx, env);
    this.env = env;
    this.storage = new Storage(ctx.storage);
    this.storage.migrations = [
      {
        idMonotonicInc: 1,
        description: "Create exports table",
        sql: `
      CREATE TABLE IF NOT EXISTS example (
        id TEXT PRIMARY KEY,
        created_at INTEGER NOT NULL DEFAULT (unixepoch()),
      );`,
      },
   ];
```
After:

```ts
const migrations: SQLSchemaMigration[] = [
      {
        idMonotonicInc: 1,
        description: "Create exports table",
        sql: `
      CREATE TABLE IF NOT EXISTS example (
        id TEXT PRIMARY KEY,
        created_at INTEGER NOT NULL DEFAULT (unixepoch()),
      );`,
      },
];

class Example extends DurableObject {
   constructor(ctx: DurableObjectState, env: Env) {
       super(ctx, env);
       this.env = env;
       this.storage = new Storage(ctx.storage);
       this.storage.migrations = migrations;
```
