### PR TITLE
Proposal for improving types in query method

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -152,23 +152,14 @@ export class Storage {
      * @param opts - Options containing the SQL query, parameters, and result format preference
      * @returns Promise resolving to either raw query results or formatted array
      */
-    private async query(sql: string, params?: unknown[], isRaw?: boolean) {
+    private async query<T = Record<string, string | number | boolean | null>>(
+        sql: string, params?: unknown[]
+    ) {
         // Now proceed with executing the query
-        const cursor = await this.executeRawQuery({ sql, params })
-        if (!cursor) return []
+        const cursor = await this.executeRawQuery({ sql, params });
+        if (!cursor) return [] as T[];
 
-        if (isRaw) {
-            return {
-                columns: cursor.columnNames,
-                rows: Array.from(cursor.raw()),
-                meta: {
-                    rows_read: cursor.rowsRead,
-                    rows_written: cursor.rowsWritten,
-                },
-            }
-        }
-
-        return cursor.toArray()
+        return cursor.toArray() as T[];
     }
 
     async runMigrations() {


### PR DESCRIPTION
This method is a little odd in that a boolean input changes the expected output type. Given that we also have [`executeRawQuery`](https://github.com/cloudflare/actors/blob/main/packages/storage/src/index.ts#L95) it seems like this might be a leftover from a previous version? I'm not sure it's needed, but let me know if I'm missing something.

Removing `isRaw` allows us to give a template output type similar to the [`sql` method](https://github.com/cloudflare/actors/blob/main/packages/storage/src/index.ts#L126), making this an equivalent function with slightly less template magic.