### PR TITLE
fix(`@Persist`): prevent heap overflow in error handler

### DIFF
--- a/packages/core/src/persist.test.ts
+++ b/packages/core/src/persist.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { __test } from "./persist";
+
+const { createDeepProxy } = __test;
+
+// No-op trigger for testing (we don't need persistence in these tests)
+const noopTrigger = () => {};
+
+/**
+ * Helper to create a proxy using the real createDeepProxy function.
+ * Uses minimal mock instance and property key for testing purposes.
+ */
+function createTestProxy<T extends object>(value: T): T {
+  return createDeepProxy(value, {}, "testProp", noopTrigger);
+}
+
+describe("persist proxy - error handler heap overflow bug", () => {
+  it("should return undefined on error instead of creating infinite proxy chain", () => {
+    // Create an object with a throwing getter
+    const throwingObj = {
+      get badProp(): never {
+        throw new Error("This getter throws");
+      },
+      normalProp: "hello",
+    };
+
+    const proxied = createTestProxy(throwingObj);
+
+    // Accessing the throwing getter should return undefined, not create {} and recurse
+    // Before the fix, this would cause a heap overflow from infinite proxy recursion
+    const result = proxied.badProp;
+
+    expect(result).toBe(undefined);
+    // The normal prop should still work
+    expect(proxied.normalProp).toBe("hello");
+  });
+
+  it("should not corrupt the original object on error", () => {
+    const original: Record<string, any> = {
+      get explosive(): never {
+        throw new Error("boom");
+      },
+    };
+
+    const proxied = createTestProxy(original);
+
+    // Access the throwing getter
+    void proxied.explosive;
+
+    // The original should not be mutated with {}
+    // Check that 'explosive' is still a getter, not {}
+    const descriptor = Object.getOwnPropertyDescriptor(original, "explosive");
+    expect(descriptor?.get).toBeDefined();
+  });
+});

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -123,10 +123,10 @@ function createDeepProxy(value: any, instance: any, propertyKey: string, trigger
                 return prop;
             } catch (e) {
                 console.error(`Error accessing property ${String(key)}:`, e);
-                // Return an empty object proxy for error recovery
-                const newObj = {};
-                Reflect.set(target, key, newObj);
-                return createDeepProxy(newObj, instance, propertyKey, triggerPersist);
+                // Return undefined on error - don't auto-vivify as it causes:
+                // 1. Silent data corruption (replaces original value with {})
+                // 2. Infinite proxy recursion leading to heap overflow
+                return undefined;
             }
         },
         set(target, key, newValue) {
@@ -514,6 +514,11 @@ function safeParse(json: string): any {
         return value;
     });
 }
+
+// Test exports - expose internal functions for unit testing
+export const __test = {
+    createDeepProxy,
+};
 
 /**
  * Helper function to persist a property value to storage.


### PR DESCRIPTION
## Summary

The `@Persist` proxy error handler was auto-vivifying `{}` on ANY error during property access, causing:

1. **Silent data corruption**: Original property values replaced with empty objects
2. **Heap overflow**: Infinite proxy recursion when the getter continues to throw

## Root Cause

```typescript
// Before: creates {} and recurses infinitely
} catch (e) {
    console.error(`Error accessing property ${String(key)}:`, e);
    const newObj = {};
    Reflect.set(target, key, newObj);
    return createDeepProxy(newObj, instance, propertyKey, triggerPersist);
}
```

If a getter throws, the error handler:
1. Creates a new empty object
2. Sets it on the target (corrupting the original)
3. Returns a new proxy wrapping the empty object
4. The next access triggers the same getter → same error → infinite loop

## Fix

```typescript
} catch (e) {
    console.error(`Error accessing property ${String(key)}:`, e);
    // Return undefined on error - don't auto-vivify
    return undefined;
}
```

## Test Plan

- [x] Added test: throwing getter returns undefined, no heap overflow
- [x] Added test: original object not corrupted on error

## Related

- #93 - Separate fix for null auto-vivification in same code area

---

Code in this PR was AI-assisted and exercised against a pet project that experienced the bug.