### PR TITLE
fixes import paths

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,12 +1,12 @@
 import { env, DurableObject, WorkerEntrypoint } from "cloudflare:workers";
-import { Storage } from "../../storage/src/index";
-import { Alarms } from "../../alarms/src/index";
-import { Sockets } from "../../sockets/src/index";
-import { Persist, PERSISTED_VALUES, initializePersistedProperties, persistProperty } from "./persist";
+import { Storage } from "../../storage/src/index.js";
+import { Alarms } from "../../alarms/src/index.js";
+import { Sockets } from "../../sockets/src/index.js";
+import { Persist, PERSISTED_VALUES, initializePersistedProperties, persistProperty } from "./persist.js";
 
 export { Persist };
 
-export * from "./retries";
+export * from "./retries.js";
 
 /**
  * Alias type for DurableObjectState to match the adopted Actor nomenclature.

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -1,4 +1,4 @@
-import { ActorState } from './index';
+import { ActorState } from './index.js';
 
 // Symbol to store persisted property metadata
 export const PERSISTED_PROPERTIES = Symbol('PERSISTED_PROPERTIES');

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,5 +1,5 @@
 import type { DurableObjectStorage } from "@cloudflare/workers-types";
-import { SQLSchemaMigration, SQLSchemaMigrations } from "./sql-schema-migrations";
+import { SQLSchemaMigration, SQLSchemaMigrations } from "./sql-schema-migrations.js";
 
 export type { SQLSchemaMigration };
 


### PR DESCRIPTION
Fixes #49 

```
The source files used relative imports without .js extensions:

import { Storage } from "../../storage/src/index";  // Missing .js

When TypeScript compiles with moduleResolution: "bundler", it doesn't add extensions. But since the package is ESM ("type": "module"), Node.js ESM resolution requires explicit .js extensions for relative imports.
```