### PR TITLE
Fix alarm exception caused by constructor consuming alarm before runtime delivery

### DIFF
--- a/packages/alarms/src/index.ts
+++ b/packages/alarms/src/index.ts
@@ -85,8 +85,8 @@ export class Alarms<P extends DurableObject<any>> {
                   }
               }
       
-              // Execute any pending alarms and schedule the next alarm
-              await this.alarm();
+              // Don't execute callbacks; the runtime delivers the alarm after init.
+              await this._scheduleNextAlarm();
             });
         });
     }
@@ -268,9 +268,9 @@ export class Alarms<P extends DurableObject<any>> {
     private async _scheduleNextAlarm() {
         // Find the next schedule that needs to be executed
         const result = this.sql`
-          SELECT time, COALESCE(identifier, 'default') as identifier FROM _actor_alarms 
+          SELECT time, COALESCE(identifier, 'default') as identifier FROM _actor_alarms
           WHERE time > ${Math.floor(Date.now() / 1000)}
-          ORDER BY time ASC 
+          ORDER BY time ASC
           LIMIT 1
         `;
         if (!result || !this.storage) return;
@@ -318,7 +318,7 @@ export class Alarms<P extends DurableObject<any>> {
             // Update next execution time for cron schedules
             const nextExecutionTime = getNextCronTime(row.cron);
             const nextTimestamp = Math.floor(nextExecutionTime.getTime() / 1000);
-    
+
             this.sql`
               UPDATE _actor_alarms SET time = ${nextTimestamp} WHERE id = ${row.id}
             `;


### PR DESCRIPTION
The `Alarms` constructor calls `await this.alarm()` inside `blockConcurrencyWhile`, consuming due alarm rows during init. The runtime then tries to deliver the same alarm after init and marks it as outcome: "exception".
                                                                                                                  
Replace `await this.alarm()` with `await this._scheduleNextAlarm()`. Only register the next alarm time during init, let the runtime handle execution.

Tested by deploying a worker with `@Persist` fields and `this.alarms.schedule()` in the callback. Before fix: intermittent exceptions on every alarm cycle, `@Persist` state resetting due to double-execution. After fix: no exceptions, state persisting correctly.
